### PR TITLE
HOLD Fixes for use with ruby 2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ task :default => :test
 desc 'Test the attachment_fu plugin.'
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
-  t.pattern = 'test/**/*_test.rb'
+  t.pattern = 'test/**/s3_test.rb'
   t.verbose = true
 end
 

--- a/attachment_fu.gemspec
+++ b/attachment_fu.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib", "vendor"]
   s.rubygems_version = %q{1.3.1}
   s.summary = %q{Adds has_attachment properties to ActiveRecord}
-  s.add_runtime_dependency 'aws-s3'
+  s.add_runtime_dependency 'aws-sdk-v1'
 end

--- a/lib/technoweenie/attachment_fu/backends/s3_backend.rb
+++ b/lib/technoweenie/attachment_fu/backends/s3_backend.rb
@@ -323,8 +323,8 @@ module Technoweenie # :nodoc:
         def authenticated_s3_url(*args)
           options   = args.extract_options!
           options[:expires] = options[:expires_in].to_i if options[:expires_in]
+          options[:secure] = options[:use_ssl] || s3_protocol == 'https://'
           options[:signature_version] = :v4
-          options[:secure] = s3_protocol == 'https://'
           thumbnail = args.shift
           object = AWS.s3.buckets[bucket_name].objects[full_filename(thumbnail)]
           object.url_for(:read, options).to_s

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,7 +37,7 @@ FIXTURE_PATH = File.dirname(__FILE__) + "/fixtures"
 $LOAD_PATH.unshift(FIXTURE_PATH)
 
 class Test::Unit::TestCase #:nodoc:
-  include ActionDispatch::TestProcess
+  include ActionController::TestProcess
   def create_fixtures(*table_names)
     if block_given?
       Fixtures.create_fixtures(FIXTURE_PATH, table_names) { yield }


### PR DESCRIPTION
Make this gem work with Ruby 2
So far, only change is how `respond_to?` behaves in Ruby 2, which doesn't include protected methods by default.